### PR TITLE
Replace node-sass with sass (dart-sass)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "autoprefixer": "^9.4.8",
     "cssnano": "^4.1.10",
-    "node-sass": "^4.11.0",
-    "postcss": "^7.0.14"
+    "postcss": "^7.0.14",
+    "sass": "^1.29.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/sass.js
+++ b/src/sass.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const util = require('util')
-const sass = require('node-sass')
+const sass = require('sass')
 
 /**
  * Transform SASS to CSS.
@@ -19,7 +18,7 @@ module.exports = async function(folderPath, str, opts) {
 	// Dismiss sourceMap when output should be optimized
 	const sourceMap = opts.optimize !== true
 
-	const result = await util.promisify(sass.render)({
+	const result = sass.renderSync({
 		data: str,
 		includePaths: [ folderPath ],
 		sourceMap: sourceMap,

--- a/src/sass.js
+++ b/src/sass.js
@@ -21,7 +21,7 @@ module.exports = async function(folderPath, str, opts) {
 	const result = sass.renderSync({
 		data: str,
 		includePaths: [ folderPath ],
-		sourceMap: sourceMap,
+		sourceMap: sourceMap ? '' : false,
 		sourceMapEmbed: sourceMap,
 		sourceMapContents: sourceMap
 	})


### PR DESCRIPTION
`node-sass` has been deprecated ([more information](https://sass-lang.com/blog/libsass-is-deprecated)). 
Also rids of the tedious issue of very often having to build node-sass every now and then